### PR TITLE
feat: rework url parsing and generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,11 +80,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -152,28 +153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
-dependencies = [
- "axum",
- "axum-core",
- "bytes",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "serde",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,30 +169,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bumpalo"
@@ -235,9 +199,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -310,25 +274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "cssparser"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,16 +324,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -523,16 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,30 +506,6 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
-
-[[package]]
-name = "headers"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
 
 [[package]]
 name = "heck"
@@ -903,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -913,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -931,9 +832,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -963,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "mac"
@@ -1007,9 +908,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1207,9 +1108,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1239,7 +1140,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -1258,7 +1159,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.9",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1322,7 +1223,6 @@ name = "rapla-ical-proxy"
 version = "0.1.0"
 dependencies = [
  "axum",
- "axum-extra",
  "chrono",
  "clap",
  "html-escape",
@@ -1382,7 +1282,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -1459,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
@@ -1554,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "sentry"
@@ -1677,9 +1577,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1717,17 +1617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae65c4249478a2647db249fb43e23cec56a2c8974a427e7bd8cb5a1d0964921a"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -1834,9 +1723,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1885,11 +1774,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1905,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2084,12 +1973,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,7 +1999,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "log",
  "once_cell",
  "rustls",
@@ -2169,18 +2052,18 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -2205,20 +2088,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -2230,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2243,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2253,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2266,15 +2150,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ repository = "https://github.com/satoqz/rapla-ical-proxy"
 
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["tokio", "http1", "http2", "query"] }
-axum-extra = { version = "0.10", default-features = false, features = ["typed-header"] }
 chrono = { version = "0.4", default-features = false, features = ["std", "now"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 html-escape = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,8 +73,7 @@ async fn main_impl(args: Args) -> io::Result<()> {
 
     // Middlewares are layered, i.e. the later it is applied the earlier it is called.
     let router = Router::new();
-    let router = crate::proxy::apply_routes(router)
-        .route("/*path", axum::routing::get(|| async { "Hello, World!" }));
+    let router = crate::proxy::apply_routes(router);
     let router = crate::cache::apply_middleware(router, cache_config);
     let router = crate::resolver::apply_middleware(router);
     let router = crate::logging::apply_middleware(router);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod helpers;
 mod logging;
 mod parser;
 mod proxy;
+mod resolver;
 
 use std::io;
 use std::net::SocketAddr;
@@ -72,8 +73,10 @@ async fn main_impl(args: Args) -> io::Result<()> {
 
     // Middlewares are layered, i.e. the later it is applied the earlier it is called.
     let router = Router::new();
-    let router = crate::proxy::apply_routes(router);
+    let router = crate::proxy::apply_routes(router)
+        .route("/*path", axum::routing::get(|| async { "Hello, World!" }));
     let router = crate::cache::apply_middleware(router, cache_config);
+    let router = crate::resolver::apply_middleware(router);
     let router = crate::logging::apply_middleware(router);
     let router = router.route_layer(sentry_hub_middleware);
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,111 @@
+use std::str::FromStr;
+
+use axum::extract::Request;
+use axum::http::Uri;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::Router;
+use chrono::{Datelike, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum RaplaBaseQuery {
+    V1 { key: String, salt: String },
+    V2 { user: String, file: String },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RaplaQueryWithPage {
+    #[serde(flatten)]
+    base: RaplaBaseQuery,
+    page: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct UpstreamUrlComponents {
+    host: String,
+    page: String,
+    query: RaplaBaseQuery,
+}
+
+impl UpstreamUrlComponents {
+    fn try_from_request(request: &Request) -> Option<Self> {
+        // Try either:
+        //  1. The request URL itself (e.g. https://rapla.satoqz.net/rapla/calendar).
+        //  2. The request path, treating it as a URL (e.g. https://rapla.satoqz.net/https://rapla.dhbw.de/rapla/calendar).
+        Self::try_from_uri(request.uri()).or_else(|| {
+            let path_and_query = request.uri().path_and_query()?;
+            let uri = Uri::from_str(path_and_query.as_str().trim_start_matches('/')).ok()?;
+            Self::try_from_uri(&uri)
+        })
+    }
+
+    const DEFAULT_HOST: &'static str = "rapla.dhbw.de";
+    const HOST_ALLOWLIST: [&'static str; 2] = ["rapla.dhbw.de", "rapla-ravensburg.dhbw.de"];
+
+    fn try_from_uri(uri: &Uri) -> Option<Self> {
+        let host = match uri.host() {
+            Some(host) if Self::HOST_ALLOWLIST.contains(&host) => host,
+            Some(_) => return None,
+            None => Self::DEFAULT_HOST,
+        };
+
+        let query: RaplaQueryWithPage = serde_urlencoded::from_str(uri.query()?).ok()?;
+        let page = match query.page {
+            Some(page) => page,
+            None => {
+                let path = uri.path();
+                if path.starts_with("/rapla/") {
+                    path.trim_start_matches("/rapla/").to_string()
+                } else {
+                    return None;
+                }
+            }
+        };
+
+        Some(UpstreamUrlComponents {
+            host: host.to_string(),
+            page,
+            query: query.base,
+        })
+    }
+
+    fn generate_url(self) -> String {
+        // These don't need to be 100% accurate.
+        const WEEKS_TWO_YEARS: usize = 104;
+        const DAYS_ONE_YEAR: i64 = 365;
+
+        let now = Utc::now();
+        let year_ago = now - Duration::try_days(DAYS_ONE_YEAR).unwrap();
+
+        format!(
+            "https://{}/rapla/{}?day={}&month={}&year={}&pages={WEEKS_TWO_YEARS}&{}",
+            self.host,
+            self.page,
+            year_ago.day(),
+            year_ago.month(),
+            year_ago.year(),
+            // There's no reason this should fail, we already parsed it in the first place.
+            serde_urlencoded::to_string(self.query).unwrap()
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpstreamUrlExtension(pub String);
+
+pub fn apply_middleware(router: Router) -> Router {
+    router.route_layer(middleware::from_fn(resolver_middleware))
+}
+
+async fn resolver_middleware(mut request: Request, next: Next) -> Response {
+    match UpstreamUrlComponents::try_from_request(&request) {
+        Some(components) => request
+            .extensions_mut()
+            .insert(UpstreamUrlExtension(components.generate_url())),
+        None => return "oh no".into_response(),
+    };
+
+    next.run(request).await
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -29,42 +29,57 @@ struct UpstreamUrlComponents {
     query: RaplaBaseQuery,
 }
 
+#[derive(Debug, Clone)]
+pub struct UpstreamUrlExtension {
+    pub url: String,
+    pub start_year: i32,
+}
+
+pub fn apply_middleware(router: Router) -> Router {
+    router.route_layer(middleware::from_fn(resolver_middleware))
+}
+
+async fn resolver_middleware(mut request: Request, next: Next) -> Response {
+    let Some(components) = UpstreamUrlComponents::from_request_uri(request.uri()) else {
+        return "Error: Could not determine upstream URL, check your request URL".into_response();
+    };
+
+    request.extensions_mut().insert(components.generate_url());
+    next.run(request).await
+}
+
 impl UpstreamUrlComponents {
-    fn try_from_request(request: &Request) -> Option<Self> {
+    const DEFAULT_HOST: &'static str = "rapla.dhbw.de";
+    const HOST_ALLOWLIST: [&'static str; 2] = ["rapla.dhbw.de", "rapla-ravensburg.dhbw.de"];
+
+    fn from_request_uri(uri: &Uri) -> Option<Self> {
         // Try either:
         //  1. The request path, treating it as a URL (e.g. https://rapla.satoqz.net/https://rapla.dhbw.de/rapla/calendar).
         //  2. The request URL itself (e.g. https://rapla.satoqz.net/rapla/calendar).
         // Order matters!!!
-        None.or_else(|| {
-            let path_and_query = request.uri().path_and_query()?;
-            let uri = Uri::from_str(path_and_query.as_str().trim_start_matches('/')).ok()?;
-            Self::try_from_uri(&uri)
-        })
-        .or_else(|| Self::try_from_uri(request.uri()))
+        let uri_in_path = uri
+            .path_and_query()
+            .map(|path| path.as_str().trim_start_matches('/'))
+            .and_then(|path| Uri::from_str(path).ok());
+
+        uri_in_path
+            .as_ref()
+            .and_then(Self::from_simple_uri)
+            .or_else(|| Self::from_simple_uri(uri))
     }
 
-    const DEFAULT_HOST: &'static str = "rapla.dhbw.de";
-    const HOST_ALLOWLIST: [&'static str; 2] = ["rapla.dhbw.de", "rapla-ravensburg.dhbw.de"];
-
-    fn try_from_uri(uri: &Uri) -> Option<Self> {
-        let host = match uri.host() {
-            Some(host) if Self::HOST_ALLOWLIST.contains(&host) => host,
-            Some(_) => return None,
-            None => Self::DEFAULT_HOST,
-        };
+    fn from_simple_uri(uri: &Uri) -> Option<Self> {
+        let host = uri.host().unwrap_or(Self::DEFAULT_HOST);
+        if !Self::HOST_ALLOWLIST.contains(&host) {
+            return None;
+        }
 
         let query: RaplaQueryWithPage = serde_urlencoded::from_str(uri.query()?).ok()?;
-        let page = match query.page {
-            Some(page) => page,
-            None => {
-                let path = uri.path();
-                if path.starts_with("/rapla/") {
-                    path.trim_start_matches("/rapla/").to_string()
-                } else {
-                    return None;
-                }
-            }
-        };
+        let page = query.page.or_else(|| {
+            let path = uri.path();
+            path.starts_with("/rapla/")
+                .then(|| path.trim_start_matches("/rapla/").to_string())
+        })?;
 
         Some(UpstreamUrlComponents {
             host: host.to_string(),
@@ -97,26 +112,4 @@ impl UpstreamUrlComponents {
             start_year: year_ago.year(),
         }
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct UpstreamUrlExtension {
-    pub url: String,
-    pub start_year: i32,
-}
-
-pub fn apply_middleware(router: Router) -> Router {
-    router.route_layer(middleware::from_fn(resolver_middleware))
-}
-
-async fn resolver_middleware(mut request: Request, next: Next) -> Response {
-    match UpstreamUrlComponents::try_from_request(&request) {
-        Some(components) => request.extensions_mut().insert(components.generate_url()),
-        None => {
-            return "Error: Could not determine upstream URL, check your request URL"
-                .into_response()
-        }
-    };
-
-    next.run(request).await
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -50,7 +50,9 @@ async fn resolver_middleware(mut request: Request, next: Next) -> Response {
 
 impl UpstreamUrlComponents {
     const DEFAULT_HOST: &'static str = "rapla.dhbw.de";
-    const HOST_ALLOWLIST: [&'static str; 2] = ["rapla.dhbw.de", "rapla-ravensburg.dhbw.de"];
+    const HOST_ALLOWLIST: [&'static str; 1] = ["rapla.dhbw.de"];
+    // TODO: Allow access to the Ravensburg instance once it supports the pages query parameter.
+    // const HOST_ALLOWLIST: [&'static str; 2] = ["rapla.dhbw.de", "rapla-ravensburg.dhbw.de"];
 
     fn from_request_uri(uri: &Uri) -> Option<Self> {
         // Try either:


### PR DESCRIPTION
This factors out the process of parsing the passed URL path + parameters and generating the upstream Rapla URL to forward the request to into a "resolver" middleware that runs before the actual proxy handler.

Additionally, this adds support for a new "URL syntax":

```
https://rapla.satoqz.net/https://rapla.dhbw.de/...
```

where you can just append the entire original Rapla link as the request path.

The original syntax:

```
https://rapla.satoqz.net/rapla/...
```

based on replacing the domain name is still supported.

Some minor bug fixes that sometimes lead to cache poisoning are also included, such as requests without a user-agent populating the cache with a 400.